### PR TITLE
Removed the NearbyMessages version from Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
 platform :ios, '7.0'
-pod 'NearbyMessages', '~> 0.9'
+pod 'NearbyMessages'
 
 link_with 'NearbyMessagesExample', 'NearbyMessagesExampleSwift'


### PR DESCRIPTION
I'd like this sample app to use the latest version of NearbyMessages without having to manually update the version number.